### PR TITLE
add default mode in help-output

### DIFF
--- a/en16931-cii2ubl-cli/src/main/java/com/helger/en16931/cii2ubl/cli/CIIToUBLConverter.java
+++ b/en16931-cii2ubl-cli/src/main/java/com/helger/en16931/cii2ubl/cli/CIIToUBLConverter.java
@@ -70,7 +70,7 @@ public class CIIToUBLConverter implements Callable <Integer>
            description = "Version of the target UBL Format: '2.1', '2.2' or '2.3' (default: ${DEFAULT-VALUE})")
   private String m_sUBLVersion;
 
-  @Option (names = "--mode", paramLabel = "mode", defaultValue = "INVOICE", description = "Allowed values: ${COMPLETION-CANDIDATES}")
+  @Option (names = "--mode", paramLabel = "mode", defaultValue = "INVOICE", description = "Allowed values: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})")
   private EUBLCreationMode m_eMode;
 
   @Option (names = { "-t", "--target" },


### PR DESCRIPTION
This is one minimal change to document the default value of "--mode" in the help output.