### PR TITLE
Support Java Modularity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ target/
 .classpath 
 zz
 release.properties
+
+# IDE, IDEA IntelliJ
+.idea/

--- a/en16931-cii2ubl-cli/src/main/java/module-info.java
+++ b/en16931-cii2ubl-cli/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module ph.cii2ubl.cli {
+    requires info.picocli;
+    requires ph.cii2ubl;
+    requires jsr305;
+    requires org.slf4j;
+    requires com.helger.commons;
+    requires com.helger.ubl21;
+    requires com.helger.ubl22;
+    requires com.helger.ubl23;
+}

--- a/en16931-cii2ubl/src/main/java/module-info.java
+++ b/en16931-cii2ubl/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module ph.cii2ubl {
+    exports com.helger.en16931.cii2ubl;
+    requires com.helger.cii.d16b;
+    requires com.helger.commons;
+    requires com.helger.jaxb;
+    requires com.helger.ubl21;
+    requires com.helger.ubl22;
+    requires com.helger.ubl23;
+    requires com.helger.ubl24;
+    requires jsr305;
+    requires org.slf4j;
+    requires com.helger.xsds.ccts.cct.schemamodule;
+    requires java.xml;
+}


### PR DESCRIPTION
* Introduce `module-info.java` files to avoid problems with illegal module name 'en16931-cii2ubl'
* Git ignore IDEA IDE configuration files

I am using mustangproject to handle e-invoices and I had  trouble with module name in transitive dependencies to this library. That's why I made these changes.